### PR TITLE
feat: position & content consistent comment removal

### DIFF
--- a/repoqa/search_needle_function.py
+++ b/repoqa/search_needle_function.py
@@ -556,6 +556,8 @@ def evaluate_model(
 
     file_base, _ = os.path.splitext(model_output_path)
     result_path = file_base + "-SCORES.json"
+    if clean_comments:
+        ignore_comments = True
     output_json = compute_score(model, dataset, model_outputs, ignore_comments)
     save_json(output_json, result_path)
 

--- a/repoqa/search_needle_function.py
+++ b/repoqa/search_needle_function.py
@@ -219,13 +219,24 @@ def clean_context_comments(
         (needle_suffix_padding + suffix_orig_size - suffix_clean_size - 1)
     )
 
-    dummy_padding = f"{COMMENT_PREFIX[language]} "
-    # Add padding
-    if needle_prefix_padding > 0:
-        prefix_cleaned = dummy_padding * needle_prefix_padding + "\n" + prefix_cleaned
+    prefix_dummy = ""
+    line = 0
+    while needle_prefix_padding > 0:
+        current = f"{COMMENT_PREFIX[language]} Line Number {line}\n"
+        current_len = len(tokenizer.tokenize(current))
+        needle_prefix_padding -= current_len
+        prefix_dummy += current
+        line += 1
+    prefix_cleaned = prefix_dummy + "\n" + prefix_cleaned
 
-    if needle_suffix_padding > 0:
-        suffix_cleaned = suffix_cleaned + dummy_padding * needle_suffix_padding + "\n"
+    suffix_dummy = ""
+    while needle_suffix_padding > 0:
+        current = f"{COMMENT_PREFIX[language]} Line Number {line}\n"
+        current_len = len(tokenizer.tokenize(current))
+        needle_suffix_padding -= current_len
+        line += 1
+        suffix_dummy += current
+    suffix_cleaned = suffix_cleaned + suffix_dummy + "\n"
 
     return prefix_cleaned, needle_cleaned, suffix_cleaned
 

--- a/repoqa/search_needle_function.py
+++ b/repoqa/search_needle_function.py
@@ -233,10 +233,10 @@ def clean_context_comments(
 def make_code_context(
     needle,
     file_content_list: List[Tuple[str, str]],
-    position_ratio,
-    code_context_size,
-    language,
-    clean_comments,
+    position_ratio: float,
+    code_context_size: int,
+    language: str,
+    clean_comments: bool = False,
 ) -> str:
     """
     Slice the file_content_list such that:
@@ -310,6 +310,8 @@ def make_code_context(
         suffix_size -= ntokens
         index += 1
 
+    # Remove the comments in code_prefix, needle_code, code_suffix and
+    # pad the code_prefix and code_suffix to maintain the position of the needle
     if clean_comments:
         code_prefix, needle_code, code_suffix = clean_context_comments(
             language,
@@ -556,9 +558,9 @@ def evaluate_model(
 
     file_base, _ = os.path.splitext(model_output_path)
     result_path = file_base + "-SCORES.json"
-    if clean_comments:
-        ignore_comments = True
-    output_json = compute_score(model, dataset, model_outputs, ignore_comments)
+    output_json = compute_score(
+        model, dataset, model_outputs, ignore_comments or clean_comments
+    )
     save_json(output_json, result_path)
 
 

--- a/repoqa/search_needle_function.py
+++ b/repoqa/search_needle_function.py
@@ -524,7 +524,7 @@ def evaluate_model(
         engine = VllmProvider(
             model,
             tensor_parallel_size=tensor_parallel_size,
-            max_model_len=int(code_context_size * 1.25),  # Magic number
+            max_model_len=int(code_context_size * 1.5),  # Magic number
             trust_remote_code=trust_remote_code,
         )
     elif backend == "anthropic":

--- a/repoqa/search_needle_function.py
+++ b/repoqa/search_needle_function.py
@@ -396,7 +396,12 @@ def evaluate_model(
 
     # resume tasks from cache if any
     # schema: {"cache_id": .., **task}
-    cache_file = os.path.join(CACHE_DIR, f"cache_ntoken_{code_context_size}_v1.jsonl")
+    extra = ""
+    if clean_ctx_comments:
+        extra += "_clean_cmt"
+    cache_file = os.path.join(
+        CACHE_DIR, f"cache{extra}_ntoken_{code_context_size}_v1.jsonl"
+    )
     os.makedirs(CACHE_DIR, exist_ok=True)
 
     cache = {}

--- a/repoqa/search_needle_function.py
+++ b/repoqa/search_needle_function.py
@@ -21,9 +21,6 @@ COMMENT_PREFIX = {
     "cpp": "//",
 }
 
-# Dummy padding for comment free
-DUMMY_PADDING = "dummy"
-
 # Model context below:
 TEMPLATE = "instruction\ncode_context\ndescription\ninstruction"
 
@@ -216,18 +213,19 @@ def clean_context_comments(
 
     # Add more padding to compensate removal from prefix/suffix portions
     needle_prefix_padding = int(
-        (needle_prefix_padding + prefix_orig_size - prefix_clean_size - 1) / 2
+        (needle_prefix_padding + prefix_orig_size - prefix_clean_size - 1)
     )
     needle_suffix_padding = int(
-        (needle_suffix_padding + suffix_orig_size - suffix_clean_size - 1) / 2
+        (needle_suffix_padding + suffix_orig_size - suffix_clean_size - 1)
     )
 
+    dummy_padding = f"{COMMENT_PREFIX[language]} "
     # Add padding
     if needle_prefix_padding > 0:
-        prefix_cleaned = DUMMY_PADDING * needle_prefix_padding + "\n" + prefix_cleaned
+        prefix_cleaned = dummy_padding * needle_prefix_padding + "\n" + prefix_cleaned
 
     if needle_suffix_padding > 0:
-        suffix_cleaned = suffix_cleaned + DUMMY_PADDING * needle_suffix_padding + "\n"
+        suffix_cleaned = suffix_cleaned + dummy_padding * needle_suffix_padding + "\n"
 
     return prefix_cleaned, needle_cleaned, suffix_cleaned
 

--- a/repoqa/search_needle_function.py
+++ b/repoqa/search_needle_function.py
@@ -359,8 +359,8 @@ def evaluate_model(
     caching: bool = True,  # if enabled, will cache the tasks which can be used to resume
     system_message: str = None,
     dataset_path: str = None,
-    clean_comments: bool = False,
-    ignore_comments: bool = False,
+    clean_ctx_comments: bool = False,
+    eval_ignore_comments: bool = False,  # ignore comments during score computation
     trust_remote_code: bool = False,
     attn_implementation=None,
 ):
@@ -475,7 +475,7 @@ def evaluate_model(
                         position_ratio=position_ratio,
                         code_context_size=code_context_size,
                         language=lang,
-                        clean_comments=clean_comments,
+                        clean_comments=clean_ctx_comments,
                     )
                     task.update(code_context_info)
                     tasks.append(task)
@@ -559,7 +559,7 @@ def evaluate_model(
     file_base, _ = os.path.splitext(model_output_path)
     result_path = file_base + "-SCORES.json"
     output_json = compute_score(
-        model, dataset, model_outputs, ignore_comments or clean_comments
+        model, dataset, model_outputs, eval_ignore_comments or clean_ctx_comments
     )
     save_json(output_json, result_path)
 


### PR DESCRIPTION
closes #43 to create a position and content-consistent comment removal evaluation. We do this by performing post-processing on the originally constructed context in `make_code_cotext`. Follows the steps:

1. Grab original constructed `prefix`, `needle_code` and `suffix` contexts
2. Remove comments from the components
3. Calculate the amount of tokens removed
4. Fill back the missing tokens using some dummy token

This approach guarantees that the comment-free context is content-consistent (i.e. the same code content just with the comments removed). The position may very slightly fluctuate (less than 1 percent difference in my testing) simply due to the dummy token used and the tokenizer

This code performs post-processing on the constructed context so no prior works should be impacted by this.